### PR TITLE
To resolve issue mentioned under below ticket,

### DIFF
--- a/src/Appender/FileAppender.cs
+++ b/src/Appender/FileAppender.cs
@@ -620,22 +620,24 @@ namespace log4net.Appender
 			private string m_filename;
 			private bool m_append;
 			private Stream m_stream = null;
+            private Mutex m_appendMutex = null;
+            private string m_appendMutexFriendlyName = "INTERPROCESS_COMMUNICATION_ACROSS_PROCESSES_USING_MUTEX";
 
-			/// <summary>
-			/// Prepares to open the file when the first message is logged.
-			/// </summary>
-			/// <param name="filename">The filename to use</param>
-			/// <param name="append">Whether to append to the file, or overwrite</param>
-			/// <param name="encoding">The encoding to use</param>
-			/// <remarks>
-			/// <para>
-			/// Open the file specified and prepare for logging. 
-			/// No writes will be made until <see cref="AcquireLock"/> is called.
-			/// Must be called before any calls to <see cref="AcquireLock"/>,
-			/// <see cref="ReleaseLock"/> and <see cref="CloseFile"/>.
-			/// </para>
-			/// </remarks>
-			public override void OpenFile(string filename, bool append, Encoding encoding)
+            /// <summary>
+            /// Prepares to open the file when the first message is logged.
+            /// </summary>
+            /// <param name="filename">The filename to use</param>
+            /// <param name="append">Whether to append to the file, or overwrite</param>
+            /// <param name="encoding">The encoding to use</param>
+            /// <remarks>
+            /// <para>
+            /// Open the file specified and prepare for logging. 
+            /// No writes will be made until <see cref="AcquireLock"/> is called.
+            /// Must be called before any calls to <see cref="AcquireLock"/>,
+            /// <see cref="ReleaseLock"/> and <see cref="CloseFile"/>.
+            /// </para>
+            /// </remarks>
+            public override void OpenFile(string filename, bool append, Encoding encoding)
 			{
 				m_filename = filename;
 				m_append = append;
@@ -671,7 +673,15 @@ namespace log4net.Appender
 				{
 					try
 					{
-						m_stream = CreateStream(m_filename, m_append, FileShare.Read);
+                        if (m_appendMutex == null)
+                        {
+                            if (!Mutex.TryOpenExisting(m_appendMutexFriendlyName, out m_appendMutex))
+                                m_appendMutex = new Mutex(false, m_appendMutexFriendlyName);
+                        }
+
+                        m_appendMutex.WaitOne();
+
+                        m_stream = CreateStream(m_filename, m_append, FileShare.Read);
 						m_append = true;
 					}
 					catch (Exception e1)
@@ -695,7 +705,10 @@ namespace log4net.Appender
 			{
 				CloseStream(m_stream);
 				m_stream = null;
-			}
+
+                if (m_appendMutex != null)
+                    m_appendMutex.ReleaseMutex();
+            }
 
 			/// <summary>
 			/// Initializes all resources used by this locking model.

--- a/src/Appender/RollingFileAppender.cs
+++ b/src/Appender/RollingFileAppender.cs
@@ -622,15 +622,23 @@ namespace log4net.Appender
 				}
 #endif
 				if (m_rollDate)
-				{
+				{   
 					DateTime n = m_dateTime.Now;
 					if (n >= m_nextCheck)
 					{
 						m_now = n;
 						m_nextCheck = NextCheckDate(m_now, m_rollPoint);
 
-						RollOverTime(true);
-					}
+                        if (!FileExists(m_scheduledFilename))
+                        {
+                            RollOverTime(true);
+                        }
+                        else
+                        {
+                            //As we are skiping rollOver, we need to pupulate new scheduled name
+                            m_scheduledFilename = CombinePath(File, m_now.ToString(m_datePattern, System.Globalization.DateTimeFormatInfo.InvariantInfo));
+                        }
+                    }
 				}
 
 				if (m_rollSize)


### PR DESCRIPTION
https://issues.apache.org/jira/browse/LOG4NET-552

services installed on production box are separate process and are configured to write log into single log file. Due to this following two issues are happening,

1. During write/append operation some processes are failing with error “Unable to acquire lock on file. The process cannot access the file because it is being used by another process”. This is because one process acquires lock (thread safe not process safe) for writing into log file and simultaneously another is trying to acquire lock and fails with above error and it just skips writing into log file.

2. During rolling operation, rolled file gets created with less than 1KB size. Thus log entries are lost. Upon investigation we found that, rolling operation is protected by system wide Mutex lock. At the time of rolling, multiple processes may come at the same time for rolling and first process will roll the original file correctly and give a different name to rolled file and re-create blank original file. Now the second process which would have come for rolling will roll the blank original file and overwrite the rolled file created by first process and thus rolled file is losing the data.

We locally have fixed above issues by changing latest log4net source code. We have kept locking model as “MinimalLock” which is current configuration in production. During  append operation for acquirelock/releaselock we added system wide mutex so that each process will wait for other process to complete append operation. Thus it will not skip log from being written.

During rolling operation we added check whether rolling is already happened by some other process. If yes then skip rolling operation. This will resolve rolling file overwrite by other process issue.